### PR TITLE
Overall improvements

### DIFF
--- a/DialScale.py
+++ b/DialScale.py
@@ -44,9 +44,9 @@ class DialScale(bpy.types.Operator):
     font = EnumProperty( name="Fonts",items=getFonts)
 
     def execute(self, context):
-        x = - self.offset
+        x = -self.offset
         y = 0.0
-        angle = math.radians( self.rotate ) + math.pi/2.0
+        angle = math.radians( self.rotate ) + math.pi/2
         angle_step = math.radians( self.segment ) / self.count
         angle = angle - angle_step
         pos = self.start - 1

--- a/DialScale.py
+++ b/DialScale.py
@@ -15,70 +15,81 @@ import mathutils
 
 from bpy.props import IntProperty,FloatProperty,StringProperty,EnumProperty,BoolProperty
 
+fonts_list = []
+
+def getFonts(self, context):
+    fonts_list = []
+    for afont in bpy.data.fonts:
+        fonts_list.append(( afont.name, afont.name,""))
+    if len(fonts_list) == 0:
+        fonts_list.append(("Bfont","Bfont",""))
+    return fonts_list
+
 class DialScale(bpy.types.Operator):
     """ Creates an array of text elements"""
     bl_idname = "curve.dial_scale"
     bl_label = "Create Dials and Scales"
     bl_options = {'REGISTER', 'UNDO'}
 
-    start = IntProperty(name="Start",description="Start value",min=0, max=100,default=1 )
+    start = IntProperty(name="Start",description="Start value",min=-10000, max=10000,default=1 )
     count = IntProperty(name="Count",description="Number of items to create",min=1, max=100, default=12  )
-    step  = IntProperty(name="Step",description="Increment of number",min=1, max=10000, default=1  ) 
-    offset = FloatProperty(name="Offset",description="Distance",min=0.01, max=100.0, default=1.0 )
-    circular = BoolProperty(name="Circular",description="Rotate Elements",default=False)    
-    rotate = FloatProperty(name="Rotation",description="Start rotation of first item",min=0.01, max=360.0, default=0.0 )
-    segment = FloatProperty(name="Segment",description="Circle Segment",min=0.0, max=360.0, default=360.0 )
-    ticks = IntProperty(name="Ticks",description="Number of ticks between numbers",min=0, max=100, default=1  ) 
+    step  = IntProperty(name="Step",description="Increment of number",min=-10000, max=10000, default=1  )
+    offset = FloatProperty(name="Offset",description="Distance",min=0.01, max=100.0, default=2.5 )
+    dialType = EnumProperty( name="Dial Type",description="Basis of creating the dial", items=[("circular","circular","A round dial"),("horizontal","horizontal","A horizontal scale"),("vertical","vertical","A vertical scale")], default="circular")
+    rotate = FloatProperty(name="Rotation",description="Start rotation of first item",min=-360.0, max=360.0, default=0.0 )
+    segment = FloatProperty(name="Segment",description="Circle Segment",min=-360.0, max=360.0, default=360.0 )
+    ticks = IntProperty(name="Ticks",description="Number of ticks between numbers",min=0, max=100, default=5  )
+    tickOffset = FloatProperty(name="Tick Offset",description="Distance to offset the Ticks",min=-100.0, max=100.0, default=1.3 )
 
-    all_fonts = []
-    for afont in bpy.data.fonts:
-        all_fonts.append(( afont.name, afont.name,""))
-    if len(all_fonts) == 0:
-        all_fonts.append(("Bfont","Bfont",""))
-    font = EnumProperty( name="Fonts",items=all_fonts )
+    font = EnumProperty( name="Fonts",items=getFonts)
 
     def execute(self, context):
-        x = -self.offset
+        x = - self.offset
         y = 0.0
-        angle = 2*math.pi+math.pi/4 - math.radians( self.rotate )
+        angle = math.radians( self.rotate ) + math.pi/2.0
         angle_step = math.radians( self.segment ) / self.count
         angle = angle - angle_step
-        pos = self.start
+        pos = self.start - 1
         num = self.start
-        end = self.count + self.start
-        if len(bpy.data.fonts) == 0:
-            # if no fonts exist we add and delete a text object to initiate it
-            bpy.ops.object.text_add()
-            context.scene.objects.unlink(bpy.data.objects['Text'])
-            bpy.data.objects.remove(bpy.data.objects['Text'])
-        font_obj = bpy.data.fonts[ self.font ]
-        bpy.context.space_data.pivot_point = 'ACTIVE_ELEMENT'
-    
+        end = self.count + self.start - 1
+
         while pos < end:
-            if self.circular:
+            if self.dialType == "circular":
                 vec3d = mathutils.Vector((self.offset, 0, 0))
                 vpos = vec3d * mathutils.Matrix.Rotation( -angle , 3, 'Z')
-            else:
+            elif self.dialType == "horizontal":
                 x = x + self.offset
                 vpos=(x,0,0)
-            angle = angle - angle_step
+            else:
+                y = y + self.offset
+                vpos = (0,y,0)
 
-            bpy.ops.object.text_add(location=(0,0, 0))
-            #bpy.ops.object.origin_set(type='ORIGIN_GEOMETRY')
-            bpy.ops.transform.translate(value=vpos)
-
+            bpy.ops.object.text_add()
             ob=bpy.context.object
             ob.data.body = str(num)
-            ob.data.font = font_obj
-            for t in range(0,self.ticks):
-                tick_step = angle_step / self.ticks
-                vec3d = mathutils.Vector((self.offset*1.3, 0, 0))
-                vrot = vec3d * mathutils.Matrix.Rotation( -(angle + t*tick_step) , 3, 'Z')
-                bpy.ops.mesh.primitive_plane_add(radius=.04 if t == 0 else .02, location=(0,0,0))
-                bpy.ops.transform.resize(value=(6,1,1))
-                bpy.ops.transform.rotate(value= angle + t*tick_step, axis=(0, 0, 1))
-                bpy.ops.transform.translate(value=vrot)
+            ob.data.font = bpy.data.fonts[ self.font ]
+            bpy.ops.object.origin_set(type='GEOMETRY_ORIGIN')
+            bpy.ops.transform.translate(value=vpos)
 
+            for t in range(0,self.ticks):
+                bpy.ops.mesh.primitive_plane_add(radius=.04 if t == 0 else .02)
+                if self.dialType == "circular":
+                    tick_step = angle_step / self.ticks
+                    vec3d = mathutils.Vector((self.offset*self.tickOffset, 0, 0))
+                    tpos = vec3d * mathutils.Matrix.Rotation( -(angle + (t*tick_step)) , 3, 'Z')
+                    bpy.ops.transform.resize(value=(6,1,1))
+                    bpy.ops.transform.rotate(value= angle + t*tick_step, axis=(0, 0, 1))
+                elif self.dialType == "horizontal":
+                    tick_step = self.offset / self.ticks
+                    tpos=(x+t*tick_step,self.tickOffset,0)
+                    bpy.ops.transform.resize(value=(1,6,1))
+                else:
+                    tick_step = self.offset / self.ticks
+                    tpos=(self.tickOffset,y+t*tick_step,0)
+                    bpy.ops.transform.resize(value=(6,1,1))
+                bpy.ops.transform.translate(value=tpos)
+
+            angle = angle - angle_step
             pos = pos + 1
             num = num + self.step
         return {'FINISHED'}


### PR DESCRIPTION
This commit makes it look like I changed everything. Primarily I cleaned up the text creation to get better font placement on circular dials. I also changed the circular option to dialType - an enum of circular, horizontal or vertical. It now also creates around the 3D cursor instead of always at 0,0,0

I left the default values set to create a clock face (some angle calcs changed to get the 12 at the top with 0.0 rotation) and adjusted the min and max of some operator properties to allow more flexibility. The ticks now work for both circular and straight options. The new tickOffset allows adjustment of the tick placement, it also allows the ticks to be moved to the opposite side of the numbers.

I also got the font selection to work. It only works on fonts loaded before the operator is run. That may sound odd but you can start blender, add a dial, select one of the text objects, load some fonts, then still adjust the operator properties, at which time changing the operator font can clear out the previously loaded fonts - not sure how it does that. Anyway loaded as an addon in preferences it no longer gets errors from the font. I also tried adding a font size but found that adjusting the size breaks the geometry to origin leaving multi-digit numbers out of place.

Overall I think it feels much more polished now.

There is still an inconsistency, doing a partial circular dial has ticks before the first number, while straight scales have them trailing after the last number.

I think I'm done playing with this one now. ;)
